### PR TITLE
Проблема разного формата content_type

### DIFF
--- a/openprocurement/documentservice/views.py
+++ b/openprocurement/documentservice/views.py
@@ -148,6 +148,7 @@ def get_view(request):
         return e.url
     else:
         request.response.content_type = doc['Content-Type']
+        request.response.content_type_params = {}
         request.response.content_disposition = doc['Content-Disposition']
         request.response.body = doc['Content']
         return request.response


### PR DESCRIPTION
Когда документ сервис работает с s3 и отдает редиректы на амазон, амазон отдает content_type без параметров(к примеру `application/pdf`). В случае же когда используется отдача файлов документсервисом, он добавляет в content_type кодировку(и получаем `application/pdf; charset=utf-8`). 
Это соответственно дает нам проблему, что заголовки до и после миграции не идентичны.
Я предлагаю 3 варианта решения:
1. Этот ПР(удаление всех параметров content_type)
2. Аналогично драйверу s3, настроить свифт-драйвер на отдачу короткоживущих урлов на свифт(при этом нужно настроить реверс-прокси выставленный в интернет, который по какому-то паттерну будет проксировать запросы на внутренний свифт)
3. Не считать это проблемой и добавить обработку этой ситуации в проверку(не желательный вариант)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.documentservice/5)
<!-- Reviewable:end -->
